### PR TITLE
fix badges for non-standard cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ ejs.filters.badge = function (t) {
 			img += 'red';
 			break;
 		default:
+			img += 'blue';
 			break;
 	}
 


### PR DESCRIPTION
always return a valid shields.io - badge, default color is blue
